### PR TITLE
Merge glossary changed into Master

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -27,6 +27,46 @@
     <main>
     <h2>Github Glossary</h2>
     <p>This is a short glossary of terms you're likely to encounter when learning Github. It's by no means complete, but should give you a good overview of commonly used terminology and their definitions.</p>
+         <dl class="glossary">
+      <dt>Add</dt>
+      <dd>Command used to stage files. Allows the user to specify which files or directories to include in the next commit.</dd>
+      <dt>Branch</dt>
+      <dd>A parallel version of a repository. Although it is contained within the same repository it allows you to develop it separately and then merge changes back into the &lsquo;live&rsquo; repository or with other branches when appropriate.</dd>
+      <dt>Checkout</dt>
+      <dd>Git command to switch to a specific file, branch, or commit. Allows you to activate older versions of files or commits or switch between active branches.</dd>
+      <dt>Clone</dt>
+      <dd>The process of copying a remote repository to your local machine. When you clone a repo you copy its entire history as well as all branches. Remote tracking for the branches is established enabling you to update and retrieve content by using basic commands without a remote reference.</dd>
+      <dt>Collaborator</dt>
+      <dd>Project team member. Collaborators are invited to participate in projects and are given read and/or write access to repos.</dd>
+      <dt>Commit</dt>
+      <dd>Snapshot of project history. Records changes to the repository with the unique hash identifier that can be referenced later to revert or rollback changes. A commit can contain the changes of a single file or a range of files and directories.</dd>
+      <dt>Fetching</dt>
+      <dd>Retrieve remote changes to a repo without merging them. A Fetch command will retrieve a remote commit but will not merge them into your local commits. This allows you to examine changes and then decide what to merge into your local history.</dd>
+      <dt>Fork</dt>
+      <dd>A local copy of another user&rsquo;s repository. Forking a project allows you to create another copy of it, which you can then edit and develop independently of the main project. Forks are tied to the source project, allowing you to issue pull requests and pull in changes to your local copy.</dd>
+      <dt>Git</dt>
+      <dd>Version control system that Github is built around. It is a widely used open source distributed version control system developed by the author of Linux.</dd>
+      <dt>Issues</dt>
+      <dd>Bug tracking system for Github. Collaborators can use issues to report bugs, request features, or set milestones for projects. Issues are tracked, reported, and closed by collaborators during the development process. They&rsquo;re a great way of communicating with your team and reporting progress.</dd>
+      <dt>Merging</dt>
+      <dd>The process of combining branches within a repo. Changes are taken from one or more branches and applied to another. When merging in Git several different methods are used to resolve conflicts and choose the appropriate changes. For the most part these methods are chosen automatically by Git. Occasionally the user will have to manually resolve conflicts, which could include editing code or choosing the proper file to use.</dd>
+      <dt>Organizations</dt>
+      <dd>Groups of collaborators organized into a team. Github allows you to create organizations with multiple collaborators that can then be administered based on repository access and read/write privileges.</dd>
+      <dt>Pull</dt>
+      <dd>Retrieve remote changes. A Pull command is similar to a Fetch command, except that it both retrieves remote changes as well as merging them in to you own commit history.</dd>
+      <dt>Pull Request</dt>
+      <dd>Proposed changes to a remote repo. Collaborators without write access can send a pull request to the administrator with the changes they've made to the repo. The administrator can then approve and merge or reject the changes to the main repository. For open source projects pull requests can be sent by anyone that has forked a project.</dd>
+      <dt>Push</dt>
+      <dd>Sending changes to a remote repo. The remote repository is updated with the changes pushed and now mirrors the local repo.</dd>
+      <dt>Rebase</dt>
+      <dd>Another way to merge changes from one branch to another. Similar to merge, rebase allows you to include changes from one branch on to another. Unlike the merge command rebase replays a branch&rsquo;s commit history onto the branch it&rsquo;s merging into. This results in a linear commit history, but overwrites previous commits.</dd>
+      <dt>Release</dt>
+      <dd>A means of tagging a specific commit. Github allows you to specify a commit as a release. This will tag the commit with a user created tag. This allows you to specify release points like 1.0 or 1.1 for projects.</dd>
+      <dt>Repo</dt>
+      <dd>Short for repository. Refers to a project folder that is being tracked by Git and containing project files. Repos can be local as well as hosted on Github.</dd>
+      <dt>Readme</dt>
+      <dd>Text file used for project info. Readme files contain project descriptions and are displayed on the main page of the project repo. These are plain text files although Github supports its own version of Markdown as well.</dd>
+    </dl>
     </main>
     <footer>
     <p>&copy; James Williamson &amp; <a href="http://www.lynda.com" title="lynda.com">lynda.com</a></p>


### PR DESCRIPTION
Added terms and definitions to the glossary page, these need to be added to the master branch.
